### PR TITLE
Add open source contributions section

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,15 @@
         </section>
 
         <section>
+            <h3>Publications</h3>
+            <ul>
+                <li><b>Decentralized Confidential Machine Learning</b> - A comprehensive exploration of
+                    privacy-preserving machine learning techniques in decentralized environments. <a
+                        href="DecentralizedConfidentialMachineLearning.pdf" target="_blank">Read Paper</a></li>
+            </ul>
+        </section>
+
+        <section>
             <h3>Speaking Engagements</h3>
             <ul>
                 <li><b>Keynote:</b> "Got Trust Issues? The Power of TEEs" at Encryption Day: ZK, FHE, & MPC during EthCC
@@ -122,11 +131,12 @@
         </section>
 
         <section>
-            <h3>Publications</h3>
+            <h3>Open Source Contributions</h3>
             <ul>
-                <li><b>Decentralized Confidential Machine Learning</b> - A comprehensive exploration of
-                    privacy-preserving machine learning techniques in decentralized environments. <a
-                        href="DecentralizedConfidentialMachineLearning.pdf" target="_blank">Read Paper</a></li>
+                <li><b>private-ml-sdk</b> - Run LLMs and agents on TEEs leveraging NVIDIA GPU TEE and Intel TDX technologies. <a href="https://github.com/nearai/private-ml-sdk" target="_blank">View on GitHub</a></li>
+                <li><b>cloud-api</b> - NEAR AI Cloud API running in TEEs. <a href="https://cloud.near.ai" target="_blank">cloud.near.ai</a> | <a href="https://github.com/nearai/cloud-api" target="_blank">View on GitHub</a></li>
+                <li><b>chat-api</b> - Private Chat API running in TEEs. <a href="https://private.near.ai" target="_blank">private.near.ai</a> | <a href="https://github.com/nearai/chat-api" target="_blank">View on GitHub</a></li>
+                <li><b>nearvault</b> - Multisig wallet on NEAR. <a href="https://nearvault.org" target="_blank">nearvault.org</a> | <a href="https://github.com/PierreLeGuen/nearvault" target="_blank">View on GitHub</a></li>
             </ul>
         </section>
 


### PR DESCRIPTION
## Summary
- Add new Open Source Contributions section featuring private-ml-sdk, cloud-api, chat-api, and nearvault
- Reorder sections: Publications now appears before Speaking Engagements

## Test plan
- [ ] Verify section order is correct
- [ ] Verify all GitHub links work
- [ ] Verify product links (cloud.near.ai, private.near.ai, nearvault.org) work